### PR TITLE
Fix FileNotFoundException caused by missing a .dll from the tools package

### DIFF
--- a/NuGetKeyVaultSignTool/NuGetKeyVaultSignTool.csproj
+++ b/NuGetKeyVaultSignTool/NuGetKeyVaultSignTool.csproj
@@ -8,9 +8,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.1" />    
-    <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.1.1" PrivateAssets="all" />
-    <ProjectReference Include="..\NuGetKeyVaultSignTool.Core\NuGetKeyVaultSignTool.Core.csproj" />    
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.CommandLineUtils" Version="1.1.1" />
+    <ProjectReference Include="..\NuGetKeyVaultSignTool.Core\NuGetKeyVaultSignTool.Core.csproj" />
   </ItemGroup>
-  
+
 </Project>


### PR DESCRIPTION
Currently version 1.2.3 of the tool fails with
```
  Unhandled Exception: System.IO.FileNotFoundException: Could not load file or assembly 'Microsoft.Extensions.CommandLineUtils, Version=1.1.1.0, Culture=neutral, PublicKeyToken=adb9793829ddae60'. The system cannot find the file specified.
     at NuGetKeyVaultSignTool.Program.Main(String[] args)
```
PrivateAssets="All" causes this assembly to be excluded from the tools nupkg.

cc @onovotny 